### PR TITLE
Fix project URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     include_package_data=True,
 
     # Details
-    url="https://github.com/dudeisbrendan03/consoleTools",
+    url="https://github.com/dudeisbrendan03/hash-verifier",
     long_description=long_description,
     long_description_content_type="text/markdown",
 


### PR DESCRIPTION
The Homepage link on PyPI points to consoleTools. This pull request makes it point to this repository instead.